### PR TITLE
Fix the problem that AsyncIter may be blocked!

### DIFF
--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -118,7 +118,9 @@ impl<'a, T: FromRedisValue + 'a> AsyncIterInner<'a, T> {
                 return None
             );
             let (cur, batch): (u64, Vec<T>) = unwrap_or!(from_redis_value(&rv).ok(), return None);
-
+            if batch.is_empty() {
+                return None;
+            }
             self.cmd.cursor = Some(cur);
             self.batch = batch.into_iter();
         }
@@ -494,7 +496,7 @@ impl Cmd {
         } else {
             (0, from_redis_value(&rv)?)
         };
-        if cursor == 0 {
+        if cursor == 0 || batch.is_empty() {
             self.cursor = None;
         } else {
             self.cursor = Some(cursor);


### PR DESCRIPTION
  async_conn.hscan_match::<_, _, Vec<u8>>(name, prefix.as_slice()).await?
or
  cmd("HSCAN")
        .arg(name).cursor_arg(0).arg("match").arg(prefix).clone()
        .iter_async::<Vec<u8>>(&mut async_conn)
        .await?;

When no data with prefix is found, it will be blocked.

Viewing the source code is due to the blockage caused by the cursor not being 0 but the return result set being empty, which will always attempt to obtain more data.

The following is the result of directly executing the Redis command in Redis cli: 127.0.0.1:6379> hscan "map001" 0 match "10206*" count 10 1) "1572864"
2) (empty array)